### PR TITLE
support spotify api limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,5 +26,5 @@ An application to manage playlists between streaming services (tidal/spotify cur
 - track playlists that get converted, build a local library.
 - handle spotify API limits
   - setup task queue or other method to batch adding items to playlist. Spotify limits the number of songs it can add to a playlist per request (100 songs)
-  - simple approach is just iteratively make n/100 requests where n = number of songs
+  - simple approach is just iteratively make n/100 requests where n = number of songs. Temporarily using this approach
 - define interfaces for playlist classes instead of hard implementations

--- a/README.md
+++ b/README.md
@@ -24,3 +24,7 @@ An application to manage playlists between streaming services (tidal/spotify cur
 - tidal auth 
 - add merge playlist functionality. Given a tidal playlist ID, update an existing spotify playlist with those songs, avoiding duplicates.
 - track playlists that get converted, build a local library.
+- handle spotify API limits
+  - setup task queue or other method to batch adding items to playlist. Spotify limits the number of songs it can add to a playlist per request (100 songs)
+  - simple approach is just iteratively make n/100 requests where n = number of songs
+- define interfaces for playlist classes instead of hard implementations

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
-			<version>1.4.200</version>
+			<version>2.1.212</version>
 		</dependency>
 
 		<dependency>

--- a/src/main/java/com/musicmaster/main/controllers/MasterExceptionHandler.java
+++ b/src/main/java/com/musicmaster/main/controllers/MasterExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.musicmaster.main.controllers;
 
+import com.musicmaster.main.exceptions.BadRequestException;
 import com.musicmaster.main.exceptions.SpotifyApiException;
 import com.musicmaster.main.exceptions.TidalApiException;
 import org.slf4j.Logger;
@@ -27,6 +28,12 @@ public class MasterExceptionHandler extends ResponseEntityExceptionHandler {
     @ResponseBody
     public ResponseEntity<String> handleTidalApiException(TidalApiException ex) {
         logger.error(ex.getMessage(), ex.getCause());
+        return new ResponseEntity<String>(ex.getMessage(), HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(BadRequestException.class)
+    @ResponseBody
+    public ResponseEntity<String> handleBadRequestException(BadRequestException ex) {
         return new ResponseEntity<String>(ex.getMessage(), HttpStatus.BAD_REQUEST);
     }
 }

--- a/src/main/java/com/musicmaster/main/controllers/PlaylistController.java
+++ b/src/main/java/com/musicmaster/main/controllers/PlaylistController.java
@@ -2,6 +2,8 @@ package com.musicmaster.main.controllers;
 
 import com.musicmaster.main.clients.SpotifyMusicSource;
 import com.musicmaster.main.clients.TidalMusicSource;
+import com.musicmaster.main.controllers.dto.CreateSpotifyPlaylistRequestBody;
+import com.musicmaster.main.exceptions.BadRequestException;
 import com.musicmaster.main.models.*;
 import com.musicmaster.main.pojo.SpotifySearchResponse;
 import com.musicmaster.main.services.PlaylistTransferService;
@@ -10,6 +12,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import javax.validation.Valid;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -63,8 +66,12 @@ public class PlaylistController {
         return tidalMusicSource.getPlaylistTracks(playlistId);
     }
 
-    @GetMapping(path = "/tidalToSpotify")
-    public Playlist copyFromTidalToSpotify(@RequestParam String playlistId, @RequestParam String playlistName) {
-        return playlistTransferService.copyTidalPlaylistToSpotify(playlistId, playlistName);
+    @PostMapping(path = "/tidalToSpotify")
+    public Playlist copyFromTidalToSpotify(@RequestBody CreateSpotifyPlaylistRequestBody requestBody) {
+        if (requestBody.getSpotifyPlaylistName() == null || requestBody.getTidalPlaylistId() == null) {
+            throw new BadRequestException("Missing required request parameter");
+        }
+        return playlistTransferService.copyTidalPlaylistToSpotify(requestBody.getTidalPlaylistId(),
+                requestBody.getSpotifyPlaylistName());
     }
 }

--- a/src/main/java/com/musicmaster/main/controllers/dto/CreateSpotifyPlaylistRequestBody.java
+++ b/src/main/java/com/musicmaster/main/controllers/dto/CreateSpotifyPlaylistRequestBody.java
@@ -1,0 +1,32 @@
+package com.musicmaster.main.controllers.dto;
+
+public class CreateSpotifyPlaylistRequestBody {
+
+    private String tidalPlaylistId;
+
+    private String spotifyPlaylistName;
+
+    public CreateSpotifyPlaylistRequestBody(final String tidalPlaylistId,
+                                            final String spotifyPlaylistName) {
+        this.tidalPlaylistId = tidalPlaylistId;
+        this.spotifyPlaylistName = spotifyPlaylistName;
+    }
+
+    public String getTidalPlaylistId() {
+        return tidalPlaylistId;
+    }
+
+    public void setTidalPlaylistId(String tidalPlaylistId) {
+        this.tidalPlaylistId = tidalPlaylistId;
+    }
+
+    public String getSpotifyPlaylistName() {
+        return spotifyPlaylistName;
+    }
+
+    public void setSpotifyPlaylistName(String spotifyPlaylistName) {
+        this.spotifyPlaylistName = spotifyPlaylistName;
+    }
+
+
+}

--- a/src/main/java/com/musicmaster/main/exceptions/BadRequestException.java
+++ b/src/main/java/com/musicmaster/main/exceptions/BadRequestException.java
@@ -1,0 +1,9 @@
+package com.musicmaster.main.exceptions;
+
+public class BadRequestException extends RuntimeException {
+
+    public BadRequestException(String message) {
+        super(message);
+    }
+
+}


### PR DESCRIPTION
- support spotify 100 song api limit
- change /tidalToSpotify endpoint to POST and created a request body
- added bad request exception handling
- updated todo list in readme
- update H2 to 2.1.212 to fix potential RCE vulnerability